### PR TITLE
Added a parameter that allows the upgrade of insecure requests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,6 @@ Imports:
     crayon,
     rstudioapi,
     stringi
-RoxygenNote: 7.1.0
+RoxygenNote: 7.2.3
 LinkingTo: 
     Rcpp

--- a/R/file_stream_server.R
+++ b/R/file_stream_server.R
@@ -340,10 +340,9 @@ lc_server_iface = R6::R6Class(
                         ...,
                         parse_md = TRUE) {
       if (parse_md) {
-        text = markdown::markdownToHTML(
+        text = markdown::mark_html(
           text = text,
-          fragment.only = TRUE,
-          extensions = markdown::markdownExtensions()
+          template = FALSE
         )
       } else {
         text = paste(text, collapse = "\n")

--- a/inst/templates/prism.html
+++ b/inst/templates/prism.html
@@ -3,6 +3,8 @@
   <head>
     <title>{title}</title>
 
+    {meta}
+
     <link href="web/progressbar/progressbar.css" rel="stylesheet" />
     <script src="web/progressbar/progressbar.min.js"></script>
 

--- a/man/file_stream_server.Rd
+++ b/man/file_stream_server.Rd
@@ -4,7 +4,15 @@
 \alias{file_stream_server}
 \title{Content-Type' = 'text/html'}
 \usage{
-file_stream_server(host, port, file, file_id, interval = 3, template = "prism")
+file_stream_server(
+  host,
+  port,
+  file,
+  file_id,
+  interval = 3,
+  template = "prism",
+  upgrade_content_security_policy
+)
 }
 \description{
 Content-Type' = 'text/html'

--- a/man/lc_server_iface.Rd
+++ b/man/lc_server_iface.Rd
@@ -20,19 +20,19 @@ The interface also provides additional tools for sending messages.
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{lc_server_iface$new()}}
-\item \href{#method-open}{\code{lc_server_iface$open()}}
-\item \href{#method-print}{\code{lc_server_iface$print()}}
-\item \href{#method-send_msg}{\code{lc_server_iface$send_msg()}}
-\item \href{#method-is_running}{\code{lc_server_iface$is_running()}}
-\item \href{#method-start}{\code{lc_server_iface$start()}}
-\item \href{#method-stop}{\code{lc_server_iface$stop()}}
-\item \href{#method-restart}{\code{lc_server_iface$restart()}}
+\item \href{#method-LiveCodeServer_Interface-new}{\code{lc_server_iface$new()}}
+\item \href{#method-LiveCodeServer_Interface-open}{\code{lc_server_iface$open()}}
+\item \href{#method-LiveCodeServer_Interface-print}{\code{lc_server_iface$print()}}
+\item \href{#method-LiveCodeServer_Interface-send_msg}{\code{lc_server_iface$send_msg()}}
+\item \href{#method-LiveCodeServer_Interface-is_running}{\code{lc_server_iface$is_running()}}
+\item \href{#method-LiveCodeServer_Interface-start}{\code{lc_server_iface$start()}}
+\item \href{#method-LiveCodeServer_Interface-stop}{\code{lc_server_iface$stop()}}
+\item \href{#method-LiveCodeServer_Interface-restart}{\code{lc_server_iface$restart()}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-new"></a>}}
-\if{latex}{\out{\hypertarget{method-new}{}}}
+\if{html}{\out{<a id="method-LiveCodeServer_Interface-new"></a>}}
+\if{latex}{\out{\hypertarget{method-LiveCodeServer_Interface-new}{}}}
 \subsection{Method \code{new()}}{
 Creates a new livecode server
 \subsection{Usage}{
@@ -43,7 +43,8 @@ Creates a new livecode server
   interval = 2,
   bitly = FALSE,
   auto_save = TRUE,
-  open_browser = TRUE
+  open_browser = TRUE,
+  upgrade_content_security_policy = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -63,13 +64,15 @@ Creates a new livecode server
 \item{\code{auto_save}}{should the broadcast file be auto saved update tic.}
 
 \item{\code{open_browser}}{should a browser session be opened.}
+
+\item{\code{upgrade_content_security_policy}}{should insecure requests be upgraded.}
 }
 \if{html}{\out{</div>}}
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-open"></a>}}
-\if{latex}{\out{\hypertarget{method-open}{}}}
+\if{html}{\out{<a id="method-LiveCodeServer_Interface-open"></a>}}
+\if{latex}{\out{\hypertarget{method-LiveCodeServer_Interface-open}{}}}
 \subsection{Method \code{open()}}{
 Open server in browser
 \subsection{Usage}{
@@ -78,8 +81,8 @@ Open server in browser
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-print"></a>}}
-\if{latex}{\out{\hypertarget{method-print}{}}}
+\if{html}{\out{<a id="method-LiveCodeServer_Interface-print"></a>}}
+\if{latex}{\out{\hypertarget{method-LiveCodeServer_Interface-print}{}}}
 \subsection{Method \code{print()}}{
 Class print method
 \subsection{Usage}{
@@ -88,8 +91,8 @@ Class print method
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-send_msg"></a>}}
-\if{latex}{\out{\hypertarget{method-send_msg}{}}}
+\if{html}{\out{<a id="method-LiveCodeServer_Interface-send_msg"></a>}}
+\if{latex}{\out{\hypertarget{method-LiveCodeServer_Interface-send_msg}{}}}
 \subsection{Method \code{send_msg()}}{
 Send a noty message to all connected users on the next update tic.
 \subsection{Usage}{
@@ -122,8 +125,8 @@ Send a noty message to all connected users on the next update tic.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-is_running"></a>}}
-\if{latex}{\out{\hypertarget{method-is_running}{}}}
+\if{html}{\out{<a id="method-LiveCodeServer_Interface-is_running"></a>}}
+\if{latex}{\out{\hypertarget{method-LiveCodeServer_Interface-is_running}{}}}
 \subsection{Method \code{is_running()}}{
 Determine if the server is running.
 \subsection{Usage}{
@@ -135,8 +138,8 @@ Returns `TRUE` if the server is running.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-start"></a>}}
-\if{latex}{\out{\hypertarget{method-start}{}}}
+\if{html}{\out{<a id="method-LiveCodeServer_Interface-start"></a>}}
+\if{latex}{\out{\hypertarget{method-LiveCodeServer_Interface-start}{}}}
 \subsection{Method \code{start()}}{
 Start the server
 \subsection{Usage}{
@@ -145,8 +148,8 @@ Start the server
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-stop"></a>}}
-\if{latex}{\out{\hypertarget{method-stop}{}}}
+\if{html}{\out{<a id="method-LiveCodeServer_Interface-stop"></a>}}
+\if{latex}{\out{\hypertarget{method-LiveCodeServer_Interface-stop}{}}}
 \subsection{Method \code{stop()}}{
 Stop the server
 \subsection{Usage}{
@@ -162,8 +165,8 @@ Stop the server
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-restart"></a>}}
-\if{latex}{\out{\hypertarget{method-restart}{}}}
+\if{html}{\out{<a id="method-LiveCodeServer_Interface-restart"></a>}}
+\if{latex}{\out{\hypertarget{method-LiveCodeServer_Interface-restart}{}}}
 \subsection{Method \code{restart()}}{
 Restart the server
 \subsection{Usage}{

--- a/man/serve_file.Rd
+++ b/man/serve_file.Rd
@@ -11,7 +11,8 @@ serve_file(
   interval = 1,
   bitly = FALSE,
   auto_save = TRUE,
-  open_browser = TRUE
+  open_browser = TRUE,
+  upgrade_content_security_policy = FALSE
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ serve_file(
 \item{auto_save}{should the broadcast file be auto saved during each update tic.}
 
 \item{open_browser}{should a browser session be opened.}
+
+\item{upgrade_content_security_policy}{should insecure requests be upgraded.}
 }
 \description{
 Create a livecode server for broadcasting a file

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // get_ipv4
 Rcpp::CharacterVector get_ipv4();
 RcppExport SEXP _livecode_get_ipv4() {


### PR DESCRIPTION
This avoids the browser block of the websocket served through ws

[CSP: upgrade-insecure-requests - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests)

This is particularly useful when streaming to the outside world using a service like ngrok (see #8)